### PR TITLE
Fix USB permission dialog not appearing on Android 14+

### DIFF
--- a/example/android/app/src/main/kotlin/com/example/dsd_flutter_example/MainActivity.kt
+++ b/example/android/app/src/main/kotlin/com/example/dsd_flutter_example/MainActivity.kt
@@ -221,8 +221,12 @@ class MainActivity : FlutterActivity() {
             pendingUsbDevice = device
             usbPermissionResult = result
             
+            // Android 14+ forbids MUTABLE PendingIntents built from implicit intents,
+            // which silently breaks USB requestPermission (no dialog -> auto-denied).
+            // Scope the intent to our package to make it explicit.
             val permissionIntent = PendingIntent.getBroadcast(
-                this, 0, Intent(ACTION_USB_PERMISSION),
+                this, 0,
+                Intent(ACTION_USB_PERMISSION).setPackage(packageName),
                 PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
             )
             usbManager.requestPermission(device, permissionIntent)


### PR DESCRIPTION
On Android 14+ (API 34+), the system forbids creating a MUTABLE PendingIntent from an implicit Intent. The permission dialog never appears and the request resolves as denied, leaving native RTL-SDR USB access silently broken.

Scope the broadcast Intent to the app package via setPackage() so it is explicit, satisfying the Android 14+ rule while keeping the PendingIntent mutable.